### PR TITLE
make no-hipaa yml use latest netrecon parse-server 

### DIFF
--- a/docker-compose.no.hipaa.yml
+++ b/docker-compose.no.hipaa.yml
@@ -2,11 +2,11 @@ version: '3.4'
 
 services:
     parse:
-        image: netreconlab/parse-hipaa:netrecon
+        image: netreconlab/parse-hipaa:latest
         environment:
             PARSE_SERVER_APPLICATION_ID: E036A0C5-6829-4B40-9B3B-3E05F6DF32B2
             PARSE_SERVER_MASTER_KEY: E2466756-93CF-4C05-BA44-FF5D9C34E99F
-            PARSE_SERVER_OBJECT_ID_SIZE: 32
+            PARSE_SERVER_OBJECT_ID_SIZE: 10
             PARSE_SERVER_DATABASE_URI: postgres://${PG_PARSE_USER}:${PG_PARSE_PASSWORD}@db:5432/${PG_PARSE_DB}
             PORT: ${PORT}
             PARSE_SERVER_MOUNT_PATH: /parse
@@ -14,7 +14,7 @@ services:
             PARSE_PUBLIC_SERVER_URL: http://localhost:${PORT}/parse
             PARSE_SERVER_CLOUD: /parse-server/cloud/main.js
             PARSE_SERVER_MOUNT_GRAPHQL: 1
-            PARSE_USING_PARSECAREKIT: 1 #If you are not using ParseCareKit, set this to 0
+            PARSE_USING_PARSECAREKIT: 0 #If you are not using ParseCareKit, set this to 0
             POSTGRES_PASSWORD: ${POSTGRES_PASSWORD} #Needed for wait-for-postgres.sh
         ports:
             - ${PORT}:${PORT}


### PR DESCRIPTION
The netrecon/parse-server is the same as parse-server except it has Postgres-client installed so it can use wait-for-postgres.sh 