### PR TITLE
Update to latest CareKit schema

### DIFF
--- a/parse/cloud/main.js
+++ b/parse/cloud/main.js
@@ -193,7 +193,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
         .setCLP(clp)
         .save()
         .then((result) => {
-          console.log("***Success: Task class created with default fields. Ignore any previous errors about this class***");
+          console.log("***Success: HealthKitTask class created with default fields. Ignore any previous errors about this class***");
          })
          .catch(error => console.log(error))
     });

--- a/parse/cloud/main.js
+++ b/parse/cloud/main.js
@@ -272,7 +272,7 @@ Parse.Cloud.define("setAuditClassLevelPermissions", async (request) =>  {
       addField: {},
       protectedFields: {}
     };
-    ParseAuditor(['_User', '_Role', '_Installaiton', '_Audience', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'HealthKitTask', 'Outcome', 'OutcomeValue', 'Note'], ['_User', '_Role', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'HealthKitTask', 'Outcome', 'OutcomeValue', 'Note'], { classPostfix: '_Audit', useMasterKey: true, clp: auditCLP });
+    ParseAuditor(['_User', '_Role', '_Installaiton', '_Audience', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'HealthKitTask', 'Outcome'], ['_User', '_Role', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'HealthKitTask', 'Outcome'], { classPostfix: '_Audit', useMasterKey: true, clp: auditCLP });
 });
 
 Parse.Cloud.job("testPatientRejectDuplicates", (request) =>  {

--- a/parse/cloud/main.js
+++ b/parse/cloud/main.js
@@ -19,21 +19,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
         addField: {},
         protectedFields: {}
     };
-        /*
-    const noteSchema = new Parse.Schema('Note');
-    await noteSchema.get()
-    .catch(error => {
-        noteSchema.addString('content')
-        .addString('title')
-        .addString('author')
-        .setCLP(clp)
-        .save()
-        .then((result) => {
-          console.log("***Success: Note class created with default fields. Ignore any previous errors about this class***");
-        })
-        .catch(error => console.log(error))
-    });*/
-    
+
     const patientSchema = new Parse.Schema('Patient');
     await patientSchema.get()
     .catch(error => {
@@ -138,36 +124,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
         })
         .catch(error => console.log(error));
     });
-    /*
-    const outcomeValueSchema = new Parse.Schema('OutcomeValue');
-    await outcomeValueSchema.get()
-    .catch(error => {
-        outcomeValueSchema.addString('uuid')
-        .addDate('createdDate')
-        .addDate('updatedDate')
-        .addNumber('logicalClock')
-        .addObject('timezone')
-        .addNumber('index')
-        .addString('kind')
-        .addString('units')
-        .addString('type')
-        .addObject('value')
-        .addString('groupIdentifier')
-        .addArray('tags')
-        .addString('source')
-        .addString('asset')
-        .addArray('notes')
-        .addString('remoteID')
-        .addObject('userInfo')
-        .addObject('schemaVersion')
-        .setCLP(clp)
-        .save()
-        .then((result) => {
-          console.log("***Success: OutcomeValue class created with default fields. Ignore any previous errors about this class***");
-        })
-        .catch(error => console.log(error))
-    });
-    */
+
     const taskSchema = new Parse.Schema('Task');
     await taskSchema.get()
     .catch(error => {
@@ -315,7 +272,7 @@ Parse.Cloud.define("setAuditClassLevelPermissions", async (request) =>  {
       addField: {},
       protectedFields: {}
     };
-    ParseAuditor(['_User', '_Role', '_Installaiton', '_Audience', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'Outcome', 'OutcomeValue', 'Note'], ['_User', '_Role', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'Outcome', 'OutcomeValue', 'Note'], { classPostfix: '_Audit', useMasterKey: true, clp: auditCLP });
+    ParseAuditor(['_User', '_Role', '_Installaiton', '_Audience', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'HealthKitTask', 'Outcome', 'OutcomeValue', 'Note'], ['_User', '_Role', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'HealthKitTask', 'Outcome', 'OutcomeValue', 'Note'], { classPostfix: '_Audit', useMasterKey: true, clp: auditCLP });
 });
 
 Parse.Cloud.job("testPatientRejectDuplicates", (request) =>  {

--- a/parse/cloud/main.js
+++ b/parse/cloud/main.js
@@ -19,33 +19,20 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
         addField: {},
         protectedFields: {}
     };
-        
+        /*
     const noteSchema = new Parse.Schema('Note');
     await noteSchema.get()
     .catch(error => {
-        noteSchema.addString('uuid')
-        .addDate('createdDate')
-        .addDate('updatedDate')
-        .addNumber('logicalClock')
-        .addObject('timezone')
-        .addString('content')
+        noteSchema.addString('content')
         .addString('title')
         .addString('author')
-        .addString('groupIdentifier')
-        .addArray('tags')
-        .addString('source')
-        .addString('asset')
-        .addArray('notes')
-        .addString('remoteID')
-        .addObject('userInfo')
-        .addObject('schemaVersion')
         .setCLP(clp)
         .save()
         .then((result) => {
           console.log("***Success: Note class created with default fields. Ignore any previous errors about this class***");
         })
         .catch(error => console.log(error))
-    });
+    });*/
     
     const patientSchema = new Parse.Schema('Patient');
     await patientSchema.get()
@@ -70,8 +57,8 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
         .addString('remoteID')
         .addObject('userInfo')
         .addObject('schemaVersion')
-        .addString('previousVersionUUID')
-        .addString('nextVersionUUID')
+        .addArray('previousVersionUUIDs')
+        .addArray('nextVersionUUIDs')
         .setCLP(clp)
         .save().then((result) => {
           console.log("***Success: Patient class created with default fields. Ignore any previous errors about this class***");
@@ -101,8 +88,8 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
         .addString('remoteID')
         .addObject('userInfo')
         .addObject('schemaVersion')
-        .addString('previousVersionUUID')
-        .addString('nextVersionUUID')
+        .addArray('previousVersionUUIDs')
+        .addArray('nextVersionUUIDs')
         .setCLP(clp)
         .save()
         .then((result) => {
@@ -142,8 +129,8 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
         .addString('remoteID')
         .addObject('userInfo')
         .addObject('schemaVersion')
-        .addString('previousVersionUUID')
-        .addString('nextVersionUUID')
+        .addArray('previousVersionUUIDs')
+        .addArray('nextVersionUUIDs')
         .setCLP(clp)
         .save()
         .then((result) => {
@@ -151,7 +138,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
         })
         .catch(error => console.log(error));
     });
-    
+    /*
     const outcomeValueSchema = new Parse.Schema('OutcomeValue');
     await outcomeValueSchema.get()
     .catch(error => {
@@ -180,7 +167,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
         })
         .catch(error => console.log(error))
     });
-    
+    */
     const taskSchema = new Parse.Schema('Task');
     await taskSchema.get()
     .catch(error => {
@@ -207,8 +194,8 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
         .addString('remoteID')
         .addObject('userInfo')
         .addObject('schemaVersion')
-        .addString('previousVersionUUID')
-        .addString('nextVersionUUID')
+        .addArray('previousVersionUUIDs')
+        .addArray('nextVersionUUIDs')
         .setCLP(clp)
         .save()
         .then((result) => {
@@ -216,7 +203,44 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
          })
          .catch(error => console.log(error))
     });
-    
+
+    const healthKitTaskSchema = new Parse.Schema('HealthKitTask');
+    await healthKitTaskSchema.get()
+    .catch(error => {
+        healthKitTaskSchema.addString('uuid')
+        .addString('entityId')
+        .addDate('createdDate')
+        .addDate('updatedDate')
+        .addDate('deletedDate')
+        .addDate('effectiveDate')
+        .addNumber('logicalClock')
+        .addObject('timezone')
+        .addString('title')
+        .addString('instructions')
+        .addBoolean('impactsAdherence')
+        .addObject('schedule')
+        .addArray('elements')
+        .addString('carePlanUUID')
+        .addPointer('carePlan', 'CarePlan')
+        .addString('groupIdentifier')
+        .addArray('tags')
+        .addString('source')
+        .addString('asset')
+        .addArray('notes')
+        .addString('remoteID')
+        .addObject('userInfo')
+        .addObject('schemaVersion')
+        .addObject('healthKitLinkage')
+        .addArray('previousVersionUUIDs')
+        .addArray('nextVersionUUIDs')
+        .setCLP(clp)
+        .save()
+        .then((result) => {
+          console.log("***Success: Task class created with default fields. Ignore any previous errors about this class***");
+         })
+         .catch(error => console.log(error))
+    });
+
     const outcomeSchema = new Parse.Schema('Outcome');
     await outcomeSchema.get()
     .catch(error => {
@@ -224,6 +248,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
         .addString('entityId')
         .addDate('createdDate')
         .addDate('updatedDate')
+        .addDate('effectiveDate')
         .addDate('deletedDate')
         .addNumber('logicalClock')
         .addObject('timezone')
@@ -241,6 +266,8 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
         .addString('remoteID')
         .addObject('userInfo')
         .addObject('schemaVersion')
+        .addArray('previousVersionUUIDs')
+        .addArray('nextVersionUUIDs')
         .setCLP(clp)
         .save()
         .then((result) => {

--- a/parse/index.js
+++ b/parse/index.js
@@ -226,6 +226,13 @@ async function createIndexes(){
     .catch(error => console.log(error));
     await adapter.ensureIndex('Task', versionedSchema, ['effectiveDate'], 'Task'+indexEffectiveDatePostfix, false)
     .catch(error => console.log(error));
+
+    await adapter.ensureUniqueness('HealthKitTask', versionedSchema, ['uuid'])
+    .catch(error => console.log(error));
+    await adapter.ensureIndex('HealthKitTask', versionedSchema, ['entityId'], 'HealthKitTask'+indexEntityIdPostfix, false)
+    .catch(error => console.log(error));
+    await adapter.ensureIndex('HealthKitTask', versionedSchema, ['effectiveDate'], 'HealthKitTask'+indexEffectiveDatePostfix, false)
+    .catch(error => console.log(error));
     
     await adapter.ensureUniqueness('Outcome', versionedSchema, ['uuid'])
     .catch(error => console.log(error));

--- a/parse/index.js
+++ b/parse/index.js
@@ -63,7 +63,7 @@ const api = new ParseServer({
    }
   },*/
   liveQuery: {
-    classNames: ["Posts", "Comments"] // List of classes to support for query subscriptions
+  classNames: ["Clock", "Patient", "CarePlan", "Contact", "Task", "Outcome"] // List of classes to support for query subscriptions
   },
   verifyUserEmails: false,
   //Setup your mail adapter
@@ -257,9 +257,8 @@ if(process.env.PARSE_SET_USER_CLP == "1"){
     },  3000);
 }
 
-
 // This will enable the Live Query real-time server
-//ParseServer.createLiveQueryServer(httpServer);
+ParseServer.createLiveQueryServer(httpServer);
 
 /*
 //Below is for SSL, but you should probably run this behind a proxy instead
@@ -274,7 +273,4 @@ var httpsServer = require('https').createServer({
 httpsServer.listen(port, host, function() {
     console.log('parse-server running on port ' + port + '.');
 });
-
-// This will enable the Live Query real-time server
-ParseServer.createLiveQueryServer(httpsServer);
 */


### PR DESCRIPTION
Modifies cloud code and main.js to work with CareKit schema changes. This isn't backwards compatible with previous comments of CareKit.

If you want Parse schema that is compatible with older and new CareKit, you should use this branch https://github.com/netreconlab/parse-hipaa/tree/carekit-2.1