### PR TITLE
Fix Password Error Message

### DIFF
--- a/parse/index.js
+++ b/parse/index.js
@@ -118,7 +118,7 @@ const api = new ParseServer({
     validatorPattern: /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{8,})/, // enforce password with at least 8 char with at least 1 lower case, 1 upper case and 1 digit
     // 2. a callback function to be invoked to validate the password
     //validatorCallback: (password) => { return validatePassword(password) },
-    validationError: 'Password must have atleast 8 characters and contain at least 1 digit.', // optional error message to be sent instead of the default "Password does not meet the Password Policy requirements." message.
+    validationError: 'Password must have at least 8 characters, contain at least 1 digit, and contain at least one special character.', // optional error message to be sent instead of the default "Password does not meet the Password Policy requirements." message.
     doNotAllowUsername: true, // optional setting to disallow username in passwords
     //maxPasswordAge: 90, // optional setting in days for password expiry. Login fails if user does not reset the password within this period after signup/last reset.
     maxPasswordHistory: 5, // optional setting to prevent reuse of previous n passwords. Maximum value that can be specified is 20. Not specifying it or specifying 0 will not enforce history.


### PR DESCRIPTION
This fixes the password error message in the parse-hippa server. We discussed in email, but in the current version the error message excludes requiring a special character to work.