### PR TITLE
Remove UUID field from objects

### DIFF
--- a/docker-compose.mongo.yml
+++ b/docker-compose.mongo.yml
@@ -17,6 +17,7 @@ services:
             PARSE_SERVER_MOUNT_GRAPHQL: 1
             PARSE_SET_USER_CLP: 1 #Default User schema so only authenticated users can access
             PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' #Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
+            PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' #Required to be true for ParseCareKit
             PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'
             PARSE_SERVER_DIRECT_ACCESS: 'false' #Known to cause crashes when true on single instance of server and not behind public server
             PARSE_SERVER_ENABLE_PRIVATE_USERS: 'false'

--- a/docker-compose.no.hipaa.yml
+++ b/docker-compose.no.hipaa.yml
@@ -17,6 +17,7 @@ services:
             PARSE_SERVER_MOUNT_GRAPHQL: 1
             PARSE_SET_USER_CLP: 1 #Default User schema so only authenticated users can access
             PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' #Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
+            PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' #Required to be true for ParseCareKit
             PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'
             PARSE_SERVER_DIRECT_ACCESS: 'false' #Known to cause crashes when true on single instance of server and not behind public server
             PARSE_SERVER_ENABLE_PRIVATE_USERS: 'false'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
             PARSE_SERVER_MOUNT_GRAPHQL: 1
             PARSE_SET_USER_CLP: 1 #Default User schema so only authenticated users can access
             PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' #Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
+            PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' #Required to be true for ParseCareKit
             PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'
             PARSE_SERVER_DIRECT_ACCESS: 'false' #Known to cause crashes when true on single instance of server and not behind public server
             PARSE_SERVER_ENABLE_PRIVATE_USERS: 'false'

--- a/parse/cloud/main.js
+++ b/parse/cloud/main.js
@@ -236,7 +236,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
     const clockSchema = new Parse.Schema('Clock');
     await clockSchema.get()
     .catch(error => {
-        clockSchema.addString('uuid')
+        clockSchema
         .addString('vector')
         .setCLP(clp)
         .save()
@@ -279,7 +279,7 @@ Parse.Cloud.job("testPatientRejectDuplicates", (request) =>  {
     const { params, headers, log, message } = request;
     
     const object = new Parse.Object('Patient');
-    object.set('uuid', "112");
+    object.set('objectId', "112");
     object.save({useMasterKey: true}).then((result) => {
       message("Saved patient");
     })
@@ -290,7 +290,7 @@ Parse.Cloud.job("testCarePlanRejectDuplicates", (request) =>  {
     const { params, headers, log, message } = request;
     
     const object = new Parse.Object('CarePlan');
-    object.set('uuid', "112");
+    object.set('objectId', "112");
     object.save({useMasterKey: true}).then((result) => {
       message("Saved carePlan");
     })
@@ -301,7 +301,7 @@ Parse.Cloud.job("testContactRejectDuplicates", (request) =>  {
     const { params, headers, log, message } = request;
     
     const object = new Parse.Object('Contact');
-    object.set('uuid', "112");
+    object.set('objectId', "112");
     object.save({useMasterKey: true}).then((result) => {
       message("Saved contact");
     })
@@ -312,7 +312,7 @@ Parse.Cloud.job("testTaskRejectDuplicates", (request) =>  {
     const { params, headers, log, message } = request;
     
     const object = new Parse.Object('Task');
-    object.set('uuid', "112");
+    object.set('objectId', "112");
     object.save({useMasterKey: true}).then((result) => {
       message("Saved task");
     })
@@ -323,33 +323,9 @@ Parse.Cloud.job("testOutcomeRejectDuplicates", (request) =>  {
     const { params, headers, log, message } = request;
     
     const object = new Parse.Object('Outcome');
-    object.set('uuid', "112");
+    object.set('objectId', "112");
     object.save({useMasterKey: true}).then((result) => {
       message("Saved outcome");
     })
     .catch(error => message(error));
 });
-
-/*
-Parse.Cloud.job("testOutcomeValueRejectDuplicates", (request) =>  {
-    const { params, headers, log, message } = request;
-    
-    const object = new Parse.Object('OutcomeValue');
-    object.set('uuid', "112");
-    object.save({useMasterKey: true}).then((result) => {
-      message("Saved outcomeValue");
-    })
-    .catch(error => message(error));
-});
-
-Parse.Cloud.job("testNoteRejectDuplicates", (request) =>  {
-    const { params, headers, log, message } = request;
-    
-    const object = new Parse.Object('Note');
-    object.set('uuid', "112");
-    object.save({useMasterKey: true}).then((result) => {
-      message("Saved note");
-    })
-    .catch(error => message(error));
-});
-*/

--- a/parse/cloud/main.js
+++ b/parse/cloud/main.js
@@ -23,7 +23,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
     const patientSchema = new Parse.Schema('Patient');
     await patientSchema.get()
     .catch(error => {
-        patientSchema.addString('uuid')
+        patientSchema
         .addString('entityId')
         .addDate('createdDate')
         .addDate('updatedDate')
@@ -55,7 +55,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
     const carePlanSchema = new Parse.Schema('CarePlan');
     await carePlanSchema.get()
     .catch(error => {
-        carePlanSchema.addString('uuid')
+        carePlanSchema
         .addString('entityId')
         .addDate('createdDate')
         .addDate('updatedDate')
@@ -87,7 +87,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
     const contactSchema = new Parse.Schema('Contact');
     await contactSchema.get()
     .catch(error => {
-        contactSchema.addString('uuid')
+        contactSchema
         .addString('entityId')
         .addDate('createdDate')
         .addDate('updatedDate')
@@ -128,7 +128,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
     const taskSchema = new Parse.Schema('Task');
     await taskSchema.get()
     .catch(error => {
-        taskSchema.addString('uuid')
+        taskSchema
         .addString('entityId')
         .addDate('createdDate')
         .addDate('updatedDate')
@@ -164,7 +164,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
     const healthKitTaskSchema = new Parse.Schema('HealthKitTask');
     await healthKitTaskSchema.get()
     .catch(error => {
-        healthKitTaskSchema.addString('uuid')
+        healthKitTaskSchema
         .addString('entityId')
         .addDate('createdDate')
         .addDate('updatedDate')
@@ -201,7 +201,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
     const outcomeSchema = new Parse.Schema('Outcome');
     await outcomeSchema.get()
     .catch(error => {
-        outcomeSchema.addString('uuid')
+        outcomeSchema
         .addString('entityId')
         .addDate('createdDate')
         .addDate('updatedDate')

--- a/parse/index.js
+++ b/parse/index.js
@@ -18,6 +18,11 @@ if (process.env.PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION == 'true'){
   allowNewClasses = true
 }
 
+var allowCustomObjectId = false;
+if (process.env.PARSE_SERVER_ALLOW_CUSTOM_OBJECTID == 'true'){
+  allowCustomObjectId = true
+}
+
 var enableSchemaHooks = false;
 if (process.env.PARSE_SERVER_ENABLE_SCHEMA_HOOKS == 'true'){
   enableSchemaHooks = true
@@ -63,6 +68,7 @@ const api = new ParseServer({
   publicServerURL: process.env.PARSE_PUBLIC_SERVER_URL || 'http://localhost:' +process.env.PORT + '/parse',
   verbose: verbose,
   allowClientClassCreation: allowNewClasses,
+  allowCustomObjectId: allowCustomObjectId,
   filesAdapter: filesAdapter,
   enableSchemaHooks: enableSchemaHooks,
   directAccess: useDirectAccess,
@@ -216,64 +222,41 @@ async function createIndexes(){
     
     const versionedSchema = {
       fields: {
-        uuid: { type: 'String' },
         entityId: { type: 'String' },
         effectiveDate: { type: 'Date' }
       },
     };
     
-    await adapter.ensureUniqueness('Patient', versionedSchema, ['uuid'])
-    .catch(error => console.log(error));
     await adapter.ensureIndex('Patient', versionedSchema, ['entityId'], 'Patient'+indexEntityIdPostfix, false)
     .catch(error => console.log(error));
     await adapter.ensureIndex('Patient', versionedSchema, ['effectiveDate'], 'Patient'+indexEffectiveDatePostfix, false)
     .catch(error => console.log(error));
 
-    await adapter.ensureUniqueness('Contact', versionedSchema, ['uuid'])
-    .catch(error => console.log(error));
     await adapter.ensureIndex('Contact', versionedSchema, ['entityId'], 'Contact'+indexEntityIdPostfix, false)
     .catch(error => console.log(error));
     await adapter.ensureIndex('Contact', versionedSchema, ['effectiveDate'], 'Contact'+indexEffectiveDatePostfix, false)
     .catch(error => console.log(error));
     
-    await adapter.ensureUniqueness('CarePlan', versionedSchema, ['uuid'])
-    .catch(error => console.log(error));
     await adapter.ensureIndex('CarePlan', versionedSchema, ['entityId'], 'CarePlan'+indexEntityIdPostfix, false)
     .catch(error => console.log(error));
     await adapter.ensureIndex('CarePlan', versionedSchema, ['effectiveDate'], 'CarePlan'+indexEffectiveDatePostfix, false)
     .catch(error => console.log(error));
     
-    await adapter.ensureUniqueness('Task', versionedSchema, ['uuid'])
-    .catch(error => console.log(error));
     await adapter.ensureIndex('Task', versionedSchema, ['entityId'], 'Task'+indexEntityIdPostfix, false)
     .catch(error => console.log(error));
     await adapter.ensureIndex('Task', versionedSchema, ['effectiveDate'], 'Task'+indexEffectiveDatePostfix, false)
     .catch(error => console.log(error));
 
-    await adapter.ensureUniqueness('HealthKitTask', versionedSchema, ['uuid'])
-    .catch(error => console.log(error));
     await adapter.ensureIndex('HealthKitTask', versionedSchema, ['entityId'], 'HealthKitTask'+indexEntityIdPostfix, false)
     .catch(error => console.log(error));
     await adapter.ensureIndex('HealthKitTask', versionedSchema, ['effectiveDate'], 'HealthKitTask'+indexEffectiveDatePostfix, false)
     .catch(error => console.log(error));
     
-    await adapter.ensureUniqueness('Outcome', versionedSchema, ['uuid'])
-    .catch(error => console.log(error));
     await adapter.ensureIndex('Outcome', versionedSchema, ['entityId'], 'Outcome'+indexEntityIdPostfix, false)
     .catch(error => console.log(error));
     
     await adapter.ensureUniqueness('Clock', schema, ['uuid'])
     .catch(error => console.log(error));
-    
-    //Because of way ParseCareKit handles this class, comment out these checks
-    /*
-    await adapter.ensureUniqueness('OutcomeValue', schema, ['uuid'])
-    .catch(error => console.log(error));
-    
-    await adapter.ensureUniqueness('Note', schema, ['uuid'])
-    .catch(error => console.log(error));
-    */
-    
 }
 
 //If you are custimizing your own user schema, set PARSE_SET_USER_CLP to 0

--- a/parse/index.js
+++ b/parse/index.js
@@ -213,13 +213,6 @@ async function createIndexes(){
     let adapter = api.config.databaseController.adapter;
     const indexEntityIdPostfix = '_entityId';
     const indexEffectiveDatePostfix = '_effectiveDate';
-    
-    const schema = {
-      fields: {
-        uuid: { type: 'String' }
-      },
-    };
-    
     const versionedSchema = {
       fields: {
         entityId: { type: 'String' },
@@ -253,9 +246,6 @@ async function createIndexes(){
     .catch(error => console.log(error));
     
     await adapter.ensureIndex('Outcome', versionedSchema, ['entityId'], 'Outcome'+indexEntityIdPostfix, false)
-    .catch(error => console.log(error));
-    
-    await adapter.ensureUniqueness('Clock', schema, ['uuid'])
     .catch(error => console.log(error));
 }
 


### PR DESCRIPTION
- [x] The `uuid` of all ParseCareKit objects is now `objectId`
- [x] allowCustomObjectId has been abled on the server

This reduces the amount of indexes that need to be managed for ParseCareKit.

**Warning** these updates are not backwards compatible with previous versions of parse-hipaa or ParseCareKit