### PR TITLE
Add CLP's for Parse classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Parse-dashboard is binded to your localhost on port 4040 and can be accessed as 
 
 1. Open your browser and go to http://localhost:4040/dashboard
 2. Username: `parse` # You can use `parseRead` to login as a read only user
-3. Password: `1234`
+3. Password: `1234` # You can generate your own password hashes here: https://bcrypt-generator.com. You can also setup multi factor authentication: https://github.com/parse-community/parse-dashboard#multi-factor-authentication-one-time-password
 4. Be sure to refresh your browser to see new changes synched from your CareKitSample app
 
 ### Configuring

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ PARSE_PUBLIC_SERVER_URL # Public Server URL, default is http://localhost:${PORT}
 PARSE_SERVER_CLOUD # Path to cloud code, default is /parse/cloud/main.js
 PARSE_SERVER_MOUNT_GRAPHQL # Enable graphql, default is 'true'
 PARSE_SET_USER_CLP # Set the Class Level Permissios of the _User schema so only authenticated users can access, default 1
-PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION # String value of 'false' or 'true'. Prohibits class creation on the client side. Classes can still be created using Parse Dashboard by `useMasterKey`, default 'false'.
+PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION # String value of 'false' or 'true'. Prohibits class creation on the client side. Classes can still be created using Parse Dashboard by `useMasterKey`, default 'false'
 PARSE_SERVER_ALLOW_CUSTOM_OBJECTID # Required to be true for ParseCareKit
 PARSE_SERVER_ENABLE_SCHEMA_HOOKS # Keeps the schema in sync across all instances
 PARSE_SERVER_DIRECT_ACCESS # Known to cause crashes when true on single instance of server and not behind public server

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ parse-hipaa is made up of four (4) seperate docker images (you use 3 of them at 
 #### netreconlab/parse-hipaa
 ```bash
 PARSE_SERVER_APPLICATION_ID # Unique string value
-PARSE_SERVER_MASTER_KEY # Unique string value
+PARSE_SERVER_PRIMARY_KEY # Unique string value
+PARSE_SERVER_READ_ONLY_PRIMARY_KEY # Unique string value
 PARSE_SERVER_ENCRYPTION_KEY # Unique string used for encrypting files stored by parse-hipaa
 PARSE_SERVER_OBJECT_ID_SIZE # Integer value, parse defaults to 10, 32 is probably better for medical apps and large tables
 PARSE_SERVER_DATABASE_URI # URI to connect to parse-hipaa. postgres://${PG_PARSE_USER}:${PG_PARSE_PASSWORD}@db:5432/${PG_PARSE_DB} or mongodb://${MONGO_PARSE_USER}:${MONGO_PARSE_PASSWORD}@db:27017/${MONGO_PARSE_DB}
@@ -55,15 +56,15 @@ PARSE_SERVER_MOUNT_PATH: # Mounting path for parse-hipaa, default is /parse
 PARSE_SERVER_URL # Server URL, default is http://parse:${PORT}/parse
 PARSE_PUBLIC_SERVER_URL # Public Server URL, default is http://localhost:${PORT}/parse
 PARSE_SERVER_CLOUD # Path to cloud code, default is /parse/cloud/main.js
-PARSE_SERVER_MOUNT_GRAPHQL # Enable graphql, default is 1
+PARSE_SERVER_MOUNT_GRAPHQL # Enable graphql, default is 'true'
 PARSE_SET_USER_CLP # Set the Class Level Permissios of the _User schema so only authenticated users can access, default 1
 PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION # String value of 'false' or 'true'. Prohibits class creation on the client side. Classes can still be created using Parse Dashboard by `useMasterKey`, default 'false'.
-PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' # Required to be true for ParseCareKit
-PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'
-PARSE_SERVER_DIRECT_ACCESS: 'false' # Known to cause crashes when true on single instance of server and not behind public server
-PARSE_SERVER_ENABLE_PRIVATE_USERS: 'false'
-PARSE_USING_PARSECAREKIT # If you are not using ParseCareKit, set this to 0, or else enable with 1. The default value is 1
-PARSE_VERBOSE: 'false'
+PARSE_SERVER_ALLOW_CUSTOM_OBJECTID # Required to be true for ParseCareKit
+PARSE_SERVER_ENABLE_SCHEMA_HOOKS # Keeps the schema in sync across all instances
+PARSE_SERVER_DIRECT_ACCESS # Known to cause crashes when true on single instance of server and not behind public server
+PARSE_SERVER_ENABLE_PRIVATE_USERS # Set to 'true' if new users should be created without public read and write access
+PARSE_USING_PARSECAREKIT # If you are not using ParseCareKit, set this to 'false', or else enable with 'true'. The default value is 'true'
+PARSE_VERBOSE # Enable verbose output on the server
 POSTGRES_PASSWORD: # Needed for wait-for-postgres.sh. Should be the same as POSTGRES_PASSWORD in netreconlab/hipaa-postgres
 ```
 
@@ -133,7 +134,7 @@ Your parse-server is binded to all of your interfaces on port 1337/parse and be 
 The standard configuration can be modified to your liking by editing [index.js](https://github.com/netreconlab/parse-hipaa/blob/master/index.js). Here you can add/modify things like push notifications, password resets, [adapters](https://github.com/parse-community/parse-server#available-adapters), etc. This file as an express app and some examples provided from parse can be found [here](https://github.com/parse-community/parse-server#using-expressjs). Note that there is no need to rebuild your image when modifying files in the "index.js" file since it is volume mounted, but you will need to restart the parse container for your changes to take effect.
 
 ### Configuring
-Default values for environment variables: `PARSE_SERVER_APPLICATION_ID` and `PARSE_SERVER_MASTER_KEY` are provided in [docker-compose.yml](https://github.com/netreconlab/parse-hipaa/blob/master/docker-compose.yml) for quick local deployment. If you plan on using this image to deploy in production, you should definitely change both values. Environment variables, `PARSE_SERVER_DATABASE_URI, PARSE_SERVER_URL, PORT, PARSE_PUBLIC_SERVER_URL, PARSE_SERVER_CLOUD, and PARSE_SERVER_MOUNT_GRAPHQL` should not be changed unles you are confident with configuring parse-server or else you image may not work properly. In particular, changing `PORT` should only be done in [.env](https://github.com/netreconlab/parse-hipaa/blob/master/.env) and will also require you to change the port manually in the [parse-dashboard-config.json](https://github.com/netreconlab/parse-hipaa/blob/master/parse-dashboard-config.json#L4) for both "serverURL" and "graphQLServerURL" to have the Parse Dashboard work correctly.
+Default values for environment variables: `PARSE_SERVER_APPLICATION_ID` and `PARSE_SERVER_PRIMARY_KEY` are provided in [docker-compose.yml](https://github.com/netreconlab/parse-hipaa/blob/master/docker-compose.yml) for quick local deployment. If you plan on using this image to deploy in production, you should definitely change both values. Environment variables, `PARSE_SERVER_DATABASE_URI, PARSE_SERVER_URL, PORT, PARSE_PUBLIC_SERVER_URL, PARSE_SERVER_CLOUD, and PARSE_SERVER_MOUNT_GRAPHQL` should not be changed unles you are confident with configuring parse-server or else you image may not work properly. In particular, changing `PORT` should only be done in [.env](https://github.com/netreconlab/parse-hipaa/blob/master/.env) and will also require you to change the port manually in the [parse-dashboard-config.json](https://github.com/netreconlab/parse-hipaa/blob/master/parse-dashboard-config.json#L4) for both "serverURL" and "graphQLServerURL" to have the Parse Dashboard work correctly.
 
 #### Running in production for ParseCareKit
 If you are plan on using parse-hipaa in production. You should run the additional scripts to create the rest of the indexes for optimized queries.
@@ -158,7 +159,7 @@ For verfying and cleaning your data along with other added functionality, you ca
 Parse-dashboard is binded to your localhost on port 4040 and can be accessed as such, e.g. http://localhost:4040/dashboard. The default login for the parse dashboard is username: "parse", password: "1234". For production you should change the password in the [postgres-dashboard-config.json](https://github.com/netreconlab/parse-hipaa/blob/master/parse-dashboard-config.json#L14). Note that ideally the password should be hashed by using something like [bcrypt-generator](https://bcrypt-generator.com) and setting "useEncryptedPasswords": false". You can also add more users through this method.
 
 1. Open your browser and go to http://localhost:4040/dashboard
-2. Username: `parse`
+2. Username: `parse` # You can use `parseRead` to login as a read only user
 3. Password: `1234`
 4. Be sure to refresh your browser to see new changes synched from your CareKitSample app
 

--- a/dashboard/parse-dashboard-config.json
+++ b/dashboard/parse-dashboard-config.json
@@ -13,11 +13,11 @@
     "users": [
     {
       "user":"parse",
-      "pass": "1234"
+      "pass": "$2a$12$mw0Bulf8PzAw8u.Zb.l0dueKGSV7z8q9bw8857av2e3yTTlC4hRca"
     },{
       "user":"parseRead",
-      "pass": "1234",
+      "pass": "$2a$12$mw0Bulf8PzAw8u.Zb.l0dueKGSV7z8q9bw8857av2e3yTTlC4hRca",
       "readOnly": true
     }],
-    "useEncryptedPasswords": false
+    "useEncryptedPasswords": true
 }

--- a/dashboard/parse-dashboard-config.json
+++ b/dashboard/parse-dashboard-config.json
@@ -19,5 +19,5 @@
       "pass": "1234",
       "readOnly": true
     }],
-    "useEncryptedPasswords": true
+    "useEncryptedPasswords": false
 }

--- a/dashboard/parse-dashboard-config.json
+++ b/dashboard/parse-dashboard-config.json
@@ -5,6 +5,7 @@
        "graphQLServerURL": "http://localhost:1337/graphql",
          "appId": "E036A0C5-6829-4B40-9B3B-3E05F6DF32B2",
          "masterKey": "E2466756-93CF-4C05-BA44-FF5D9C34E99F",
+         "readOnlyMasterKey": "367F7395-2E3A-46B1-ABA3-963A25D533C3",
          "appName": "Parse HIPAA",
          "supportedPushLocales": ["en"]
     }],
@@ -13,6 +14,10 @@
     {
       "user":"parse",
       "pass": "1234"
+    },{
+      "user":"parseRead",
+      "pass": "1234",
+      "readOnly": true
     }],
-    "useEncryptedPasswords": false
+    "useEncryptedPasswords": true
 }

--- a/docker-compose.mongo.yml
+++ b/docker-compose.mongo.yml
@@ -5,7 +5,8 @@ services:
         image: netreconlab/parse-hipaa:4.10.4
         environment:
             PARSE_SERVER_APPLICATION_ID: E036A0C5-6829-4B40-9B3B-3E05F6DF32B2
-            PARSE_SERVER_MASTER_KEY: E2466756-93CF-4C05-BA44-FF5D9C34E99F
+            PARSE_SERVER_PRIMARY_KEY: E2466756-93CF-4C05-BA44-FF5D9C34E99F
+            PARSE_SERVER_READ_ONLY_PRIMARY_KEY: 367F7395-2E3A-46B1-ABA3-963A25D533C3
             PARSE_SERVER_ENCRYPTION_KEY: 72F8F23D-FDDB-4792-94AE-72897F0688F9
             PARSE_SERVER_OBJECT_ID_SIZE: 32
             PARSE_SERVER_DATABASE_URI: mongodb://${MONGO_PARSE_USER}:${MONGO_PARSE_PASSWORD}@db:27017/${MONGO_PARSE_DB}
@@ -14,14 +15,15 @@ services:
             PARSE_SERVER_URL: http://parse:${PORT}/parse
             PARSE_PUBLIC_SERVER_URL: http://localhost:${PORT}/parse
             PARSE_SERVER_CLOUD: /parse-server/cloud/main.js
-            PARSE_SERVER_MOUNT_GRAPHQL: 1
-            PARSE_SET_USER_CLP: 1 #Default User schema so only authenticated users can access
+            PARSE_SERVER_MOUNT_GRAPHQL: 'true'
+            PARSE_SET_USER_CLP: 'true' # Default User schema so only authenticated users can access
             PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' #Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
-            PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' #Required to be true for ParseCareKit
+            PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' # Required to be true for ParseCareKit
             PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'
-            PARSE_SERVER_DIRECT_ACCESS: 'false' #Known to cause crashes when true on single instance of server and not behind public server
+            PARSE_SERVER_DIRECT_ACCESS: 'false' # Known to cause crashes when true on single instance of server and not behind public server
             PARSE_SERVER_ENABLE_PRIVATE_USERS: 'false'
-            PARSE_USING_PARSECAREKIT: 1 #If you are not using ParseCareKit, set this to 0
+            PARSE_USING_PARSECAREKIT: 'true' # If you are not using ParseCareKit, set this to 'false'
+            PARSE_VERBOSE: 'false'
         ports:
             - ${PORT}:${PORT}
         volumes:
@@ -35,8 +37,8 @@ services:
         image: parseplatform/parse-dashboard:3.2.1
         environment:
             PARSE_DASHBOARD_TRUST_PROXY: 1
-            PARSE_DASHBOARD_COOKIE_SESSION_SECRET: AB8849B6-D725-4A75-AA73-AB7103F0363F #This should be constant across all deployments on your system
-            MOUNT_PATH: /dashboard              #This needs to be exactly what you plan it to be behind the proxy, i.e. If you want to access cs.uky.edu/dashboard it should be "/dashboard"
+            PARSE_DASHBOARD_COOKIE_SESSION_SECRET: AB8849B6-D725-4A75-AA73-AB7103F0363F # This should be constant across all deployments on your system
+            MOUNT_PATH: /dashboard # This needs to be exactly what you plan it to be behind the proxy, i.e. If you want to access cs.uky.edu/dashboard it should be "/dashboard"
         command: parse-dashboard --dev
         volumes:
             - ./dashboard/parse-dashboard-config.json:/src/Parse-Dashboard/parse-dashboard-config.json
@@ -53,7 +55,7 @@ services:
         restart: always
         ports:
             - 27017:27017
-        #Uncomment volumes below to persist postgres data. Make sure to change directory to store data locally
+        # Uncomment volumes below to persist postgres data. Make sure to change directory to store data locally
         #volumes:
         #  - /My/Encrypted/Drive/db:/data/db
         #  - /My/Encrypted/Drive/log/:/mongologs

--- a/docker-compose.no.hipaa.yml
+++ b/docker-compose.no.hipaa.yml
@@ -5,7 +5,8 @@ services:
         image: netreconlab/parse-hipaa:4.10.4
         environment:
             PARSE_SERVER_APPLICATION_ID: E036A0C5-6829-4B40-9B3B-3E05F6DF32B2
-            PARSE_SERVER_MASTER_KEY: E2466756-93CF-4C05-BA44-FF5D9C34E99F
+            PARSE_SERVER_PRIMARY_KEY: E2466756-93CF-4C05-BA44-FF5D9C34E99F
+            PARSE_SERVER_READ_ONLY_PRIMARY_KEY: 367F7395-2E3A-46B1-ABA3-963A25D533C3
             PARSE_SERVER_ENCRYPTION_KEY: 72F8F23D-FDDB-4792-94AE-72897F0688F9
             PARSE_SERVER_OBJECT_ID_SIZE: 10
             PARSE_SERVER_DATABASE_URI: postgres://${PG_PARSE_USER}:${PG_PARSE_PASSWORD}@db:5432/${PG_PARSE_DB}
@@ -14,22 +15,23 @@ services:
             PARSE_SERVER_URL: http://parse:${PORT}/parse
             PARSE_PUBLIC_SERVER_URL: http://localhost:${PORT}/parse
             PARSE_SERVER_CLOUD: /parse-server/cloud/main.js
-            PARSE_SERVER_MOUNT_GRAPHQL: 1
-            PARSE_SET_USER_CLP: 1 #Default User schema so only authenticated users can access
-            PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' #Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
-            PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' #Required to be true for ParseCareKit
+            PARSE_SERVER_MOUNT_GRAPHQL: 'true'
+            PARSE_SET_USER_CLP: 'true' # Default User schema so only authenticated users can access
+            PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' # Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
+            PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' # Required to be true for ParseCareKit
             PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'
-            PARSE_SERVER_DIRECT_ACCESS: 'false' #Known to cause crashes when true on single instance of server and not behind public server
+            PARSE_SERVER_DIRECT_ACCESS: 'false' # Known to cause crashes when true on single instance of server and not behind public server
             PARSE_SERVER_ENABLE_PRIVATE_USERS: 'false'
-            PARSE_USING_PARSECAREKIT: 0 #If you are not using ParseCareKit, set this to 0
-            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD} #Needed for wait-for-postgres.sh
+            PARSE_USING_PARSECAREKIT: 'false' # If you are not using ParseCareKit, set this to 'false'
+            PARSE_VERBOSE: 'false'
+            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD} # Needed for wait-for-postgres.sh
         ports:
             - ${PORT}:${PORT}
         volumes:
             - ./scripts/wait-for-postgres.sh:/parse-server/wait-for-postgres.sh
             - ./parse/index.js:/parse-server/index.js
             - ./parse/cloud:/parse-server/cloud
-            - ./files:/parse-server/files #All files uploaded from users are stored to an ecrypted drive locally for HIPAA compliance
+            - ./files:/parse-server/files # All files uploaded from users are stored to an ecrypted drive locally for HIPAA compliance
         restart: always
         depends_on:
             - db
@@ -38,8 +40,8 @@ services:
         image: parseplatform/parse-dashboard:3.2.1
         environment:
             PARSE_DASHBOARD_TRUST_PROXY: 1
-            PARSE_DASHBOARD_COOKIE_SESSION_SECRET: AB8849B6-D725-4A75-AA73-AB7103F0363F #This should be constant across all deployments on your system
-            MOUNT_PATH: /dashboard              #This needs to be exactly what you plan it to be behind the proxy, i.e. If you want to access cs.uky.edu/dashboard it should be "/dashboard"
+            PARSE_DASHBOARD_COOKIE_SESSION_SECRET: AB8849B6-D725-4A75-AA73-AB7103F0363F # This should be constant across all deployments on your system
+            MOUNT_PATH: /dashboard # This needs to be exactly what you plan it to be behind the proxy, i.e. If you want to access cs.uky.edu/dashboard it should be "/dashboard"
         command: parse-dashboard --dev
         volumes:
             - ./dashboard/parse-dashboard-config.json:/src/Parse-Dashboard/parse-dashboard-config.json
@@ -57,7 +59,7 @@ services:
         restart: always
         ports:
             - 5432:5432
-    #Uncomment volumes below to persist postgres data. Make sure to change directory to store data locally
+    # Uncomment volumes below to persist postgres data. Make sure to change directory to store data locally
     #volumes:
     #    - ./data:/var/lib/postgresql/data
     scan:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
         image: netreconlab/parse-hipaa:5.0.0-beta.3
         environment:
             PARSE_SERVER_APPLICATION_ID: E036A0C5-6829-4B40-9B3B-3E05F6DF32B2
-            PARSE_SERVER_MASTER_KEY: E2466756-93CF-4C05-BA44-FF5D9C34E99F
+            PARSE_SERVER_PRIMARY_KEY: E2466756-93CF-4C05-BA44-FF5D9C34E99F
+            PARSE_SERVER_READ_ONLY_PRIMARY_KEY: 367F7395-2E3A-46B1-ABA3-963A25D533C3
             PARSE_SERVER_ENCRYPTION_KEY: 72F8F23D-FDDB-4792-94AE-72897F0688F9
             PARSE_SERVER_OBJECT_ID_SIZE: 32
             PARSE_SERVER_DATABASE_URI: postgres://${PG_PARSE_USER}:${PG_PARSE_PASSWORD}@db:5432/${PG_PARSE_DB}
@@ -14,14 +15,14 @@ services:
             PARSE_SERVER_URL: http://parse:${PORT}/parse
             PARSE_PUBLIC_SERVER_URL: http://localhost:${PORT}/parse
             PARSE_SERVER_CLOUD: /parse-server/cloud/main.js
-            PARSE_SERVER_MOUNT_GRAPHQL: 1
-            PARSE_SET_USER_CLP: 1 # Default User schema so only authenticated users can access
+            PARSE_SERVER_MOUNT_GRAPHQL: 'true'
+            PARSE_SET_USER_CLP: 'true' # Default User schema so only authenticated users can access
             PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' # Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
             PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' # Required to be true for ParseCareKit
             PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'
             PARSE_SERVER_DIRECT_ACCESS: 'false' # Known to cause crashes when true on single instance of server and not behind public server
             PARSE_SERVER_ENABLE_PRIVATE_USERS: 'false'
-            PARSE_USING_PARSECAREKIT: 1 # If you are not using ParseCareKit, set this to 0
+            PARSE_USING_PARSECAREKIT: 'true' # If you are not using ParseCareKit, set this to 'false'
             PARSE_VERBOSE: 'false'
             POSTGRES_PASSWORD: ${POSTGRES_PASSWORD} # Needed for wait-for-postgres.sh
         ports:

--- a/parse/cloud/main.js
+++ b/parse/cloud/main.js
@@ -16,8 +16,8 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
         create: { requiresAuthentication: true },
         update: { requiresAuthentication: true },
         delete: { requiresAuthentication: true },
-        addField: {},
-        protectedFields: {}
+        addField: { },
+        protectedFields: { }
     };
 
     const patientSchema = new Parse.Schema('Patient');
@@ -259,9 +259,9 @@ Parse.Cloud.define("setParseClassLevelPermissions", async (request) =>  {
       update: { requiresAuthentication: true },
       delete: { requiresAuthentication: true },
       addField: { requiresAuthentication: true },
-      protectedFields: {}
+      protectedFields: { }
     });
-    await userSchema.update({useMasterKey: true});
+    await userSchema.update({ useMasterKey: true });
     // Can uncomment out below once the respective Schema's are created.
     /*
     try {
@@ -274,9 +274,9 @@ Parse.Cloud.define("setParseClassLevelPermissions", async (request) =>  {
         update: { requiresAuthentication: true },
         delete: { requiresAuthentication: true },
         addField: { requiresAuthentication: true },
-        protectedFields: {}
+        protectedFields: { }
       });
-      await installationSchema.update({useMasterKey: true});
+      await installationSchema.update({ useMasterKey: true });
     } catch(error) { console.log(error); }
 
     try {
@@ -289,9 +289,9 @@ Parse.Cloud.define("setParseClassLevelPermissions", async (request) =>  {
         update: { requiresAuthentication: true },
         delete: { requiresAuthentication: true },
         addField: { },
-        protectedFields: {}
+        protectedFields: { }
       });
-      await sessionSchema.update({useMasterKey: true});
+      await sessionSchema.update({ useMasterKey: true });
     } catch(error) { console.log(error); }
 
     try {
@@ -304,9 +304,9 @@ Parse.Cloud.define("setParseClassLevelPermissions", async (request) =>  {
         update: { requiresAuthentication: true },
         delete: { requiresAuthentication: true },
         addField: { requiresAuthentication: true },
-        protectedFields: {}
+        protectedFields: { }
       });
-      await roleSchema.update({useMasterKey: true});
+      await roleSchema.update({ useMasterKey: true });
     } catch(error) { console.log(error); }
 
     try {
@@ -319,9 +319,9 @@ Parse.Cloud.define("setParseClassLevelPermissions", async (request) =>  {
         update: { requiresAuthentication: true },
         delete: { requiresAuthentication: true },
         addField: { requiresAuthentication: true },
-        protectedFields: {}
+        protectedFields: { }
       });
-      await audienceSchema.update({useMasterKey: true});
+      await audienceSchema.update({ useMasterKey: true });
     } catch(error) { console.log(error); }
     */
 });
@@ -330,11 +330,11 @@ Parse.Cloud.define("setAuditClassLevelPermissions", async (request) =>  {
     const auditCLP = {
       get: { requiresAuthentication: true },
       find: { requiresAuthentication: true },
-      create: {},
+      create: { },
       update: { requiresAuthentication: true },
       delete: { requiresAuthentication: true },
-      addField: {},
-      protectedFields: {}
+      addField: { },
+      protectedFields: { }
     };
     const modifiedClasses = ['_User', '_Role', '_Installation', '_Audience', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'HealthKitTask', 'Outcome'];
     const accessedClasses = ['_User', '_Role', '_Installation', '_Audience', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'HealthKitTask', 'Outcome'];
@@ -346,7 +346,7 @@ Parse.Cloud.job("testPatientRejectDuplicates", (request) =>  {
     
     const object = new Parse.Object('Patient');
     object.set('objectId', "112");
-    object.save({useMasterKey: true}).then((result) => {
+    object.save({ useMasterKey: true }).then((result) => {
       message("Saved patient");
     })
     .catch(error => message(error));
@@ -357,7 +357,7 @@ Parse.Cloud.job("testCarePlanRejectDuplicates", (request) =>  {
     
     const object = new Parse.Object('CarePlan');
     object.set('objectId', "112");
-    object.save({useMasterKey: true}).then((result) => {
+    object.save({ useMasterKey: true }).then((result) => {
       message("Saved carePlan");
     })
     .catch(error => message(error));
@@ -368,7 +368,7 @@ Parse.Cloud.job("testContactRejectDuplicates", (request) =>  {
     
     const object = new Parse.Object('Contact');
     object.set('objectId', "112");
-    object.save({useMasterKey: true}).then((result) => {
+    object.save({ useMasterKey: true }).then((result) => {
       message("Saved contact");
     })
     .catch(error => message(error));
@@ -379,7 +379,7 @@ Parse.Cloud.job("testTaskRejectDuplicates", (request) =>  {
     
     const object = new Parse.Object('Task');
     object.set('objectId', "112");
-    object.save({useMasterKey: true}).then((result) => {
+    object.save({ useMasterKey: true }).then((result) => {
       message("Saved task");
     })
     .catch(error => message(error));
@@ -390,7 +390,7 @@ Parse.Cloud.job("testOutcomeRejectDuplicates", (request) =>  {
     
     const object = new Parse.Object('Outcome');
     object.set('objectId', "112");
-    object.save({useMasterKey: true}).then((result) => {
+    object.save({ useMasterKey: true }).then((result) => {
       message("Saved outcome");
     })
     .catch(error => message(error));

--- a/parse/cloud/main.js
+++ b/parse/cloud/main.js
@@ -249,7 +249,7 @@ Parse.Cloud.define("ensureClassDefaultFieldsForParseCareKit", async (request) =>
     }
 });
 
-Parse.Cloud.define("setUserClassLevelPermissions", async (request) =>  {
+Parse.Cloud.define("setParseClassLevelPermissions", async (request) =>  {
     const userSchema = new Parse.Schema('_User');
     await userSchema.get();
     userSchema.setCLP({
@@ -258,10 +258,72 @@ Parse.Cloud.define("setUserClassLevelPermissions", async (request) =>  {
       create: { '*': true },
       update: { requiresAuthentication: true },
       delete: { requiresAuthentication: true },
-      addField: {},
+      addField: { requiresAuthentication: true },
       protectedFields: {}
     });
     await userSchema.update({useMasterKey: true});
+    // Can uncomment out below once the respective Schema's are created.
+    /*
+    try {
+      const installationSchema = new Parse.Schema('_Installation');
+      await installationSchema.get();
+      installationSchema.setCLP({
+        get: { requiresAuthentication: true },
+        find: { requiresAuthentication: true },
+        create: { requiresAuthentication: true },
+        update: { requiresAuthentication: true },
+        delete: { requiresAuthentication: true },
+        addField: { requiresAuthentication: true },
+        protectedFields: {}
+      });
+      await installationSchema.update({useMasterKey: true});
+    } catch(error) { console.log(error); }
+
+    try {
+      const sessionSchema = new Parse.Schema('_Session');
+      await sessionSchema.get();
+      sessionSchema.setCLP({
+        get: { requiresAuthentication: true },
+        find: { requiresAuthentication: true },
+        create: { '*': true },
+        update: { requiresAuthentication: true },
+        delete: { requiresAuthentication: true },
+        addField: { },
+        protectedFields: {}
+      });
+      await sessionSchema.update({useMasterKey: true});
+    } catch(error) { console.log(error); }
+
+    try {
+      const roleSchema = new Parse.Schema('_Role');
+      await roleSchema.get();
+      roleSchema.setCLP({
+        get: { requiresAuthentication: true },
+        find: { requiresAuthentication: true },
+        create: { requiresAuthentication: true },
+        update: { requiresAuthentication: true },
+        delete: { requiresAuthentication: true },
+        addField: { requiresAuthentication: true },
+        protectedFields: {}
+      });
+      await roleSchema.update({useMasterKey: true});
+    } catch(error) { console.log(error); }
+
+    try {
+      const audienceSchema = new Parse.Schema('_Audience');
+      await audienceSchema.get();
+      audienceSchema.setCLP({
+        get: { requiresAuthentication: true },
+        find: { requiresAuthentication: true },
+        create: { requiresAuthentication: true },
+        update: { requiresAuthentication: true },
+        delete: { requiresAuthentication: true },
+        addField: { requiresAuthentication: true },
+        protectedFields: {}
+      });
+      await audienceSchema.update({useMasterKey: true});
+    } catch(error) { console.log(error); }
+    */
 });
 
 Parse.Cloud.define("setAuditClassLevelPermissions", async (request) =>  {
@@ -274,7 +336,9 @@ Parse.Cloud.define("setAuditClassLevelPermissions", async (request) =>  {
       addField: {},
       protectedFields: {}
     };
-    ParseAuditor(['_User', '_Role', '_Installation', '_Audience', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'HealthKitTask', 'Outcome'], ['_User', '_Role', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'HealthKitTask', 'Outcome'], { classPostfix: '_Audit', useMasterKey: true, clp: auditCLP });
+    const modifiedClasses = ['_User', '_Role', '_Installation', '_Audience', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'HealthKitTask', 'Outcome'];
+    const accessedClasses = ['_User', '_Role', '_Installation', '_Audience', 'Clock', 'Patient', 'CarePlan', 'Contact', 'Task', 'HealthKitTask', 'Outcome'];
+    ParseAuditor(modifiedClasses, accessedClasses, { classPostfix: '_Audit', useMasterKey: true, clp: auditCLP });
 });
 
 Parse.Cloud.job("testPatientRejectDuplicates", (request) =>  {

--- a/parse/index.js
+++ b/parse/index.js
@@ -59,8 +59,8 @@ const api = new ParseServer({
   databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
   cloud: process.env.PARSE_SERVER_CLOUD || __dirname + '/cloud/main.js',
   appId: process.env.PARSE_SERVER_APPLICATION_ID || 'myAppId',
-  masterKey: process.env.PARSE_SERVER_MASTER_KEY || '', //Add your master key here. Keep it secret!
-  //readOnlyMasterKey: process.env.PARSE_SERVER_READ_ONLY_MASTER_KEY,
+  masterKey: process.env.PARSE_SERVER_PRIMARY_KEY || 'myKey', // Keep it secret!
+  readOnlyMasterKey: process.env.PARSE_SERVER_READ_ONLY_PRIMARY_KEY || 'myOtherKey',
   encryptionKey: process.env.PARSE_SERVER_ENCRYPTION_KEY,
   objectIdSize: parseInt(process.env.PARSE_SERVER_OBJECT_ID_SIZE) || 10,
   serverURL: process.env.PARSE_SERVER_URL || 'http://localhost:' +process.env.PORT + '/parse',  // Don't forget to change to https if needed
@@ -173,7 +173,7 @@ app.get('/', function(req, res) {
   res.status(200).send('I dream of being a website.  Please start the parse-server repo on GitHub!');
 });
 
-if(process.env.PARSE_SERVER_MOUNT_GRAPHQL){
+if(process.env.PARSE_SERVER_MOUNT_GRAPHQL == 'true'){
   const parseGraphQLServer = new ParseGraphQLServer(
     api,
     {
@@ -186,7 +186,7 @@ if(process.env.PARSE_SERVER_MOUNT_GRAPHQL){
 }
 
 // If you are not using ParseCareKit, set PARSE_USING_PARSECAREKIT to 0
-if(process.env.PARSE_USING_PARSECAREKIT == "1"){
+if(process.env.PARSE_USING_PARSECAREKIT == 'true'){
   createIndexes();
 }
 
@@ -275,12 +275,12 @@ async function createIndexes(){
   } catch(error) { console.log(error); }
 }
 
-// If you are custimizing your own user schema, set PARSE_SET_USER_CLP to 0
-if(process.env.PARSE_SET_USER_CLP == "1"){
+// If you are custimizing your own user schema, set PARSE_SET_USER_CLP to `false`
+if(process.env.PARSE_SET_USER_CLP == 'true'){
     //Fire after 5 seconds to allow _User class to be created
     setTimeout(async function() {
-      await Parse.Cloud.run('setUserClassLevelPermissions');
-      if(process.env.PARSE_USING_PARSECAREKIT == "1"){
+      await Parse.Cloud.run('setParseClassLevelPermissions');
+      if(process.env.PARSE_USING_PARSECAREKIT == 'true'){
         Parse.Cloud.run('setAuditClassLevelPermissions');
       }
     }, 3000);


### PR DESCRIPTION
- [x] Shows examples of how to set CLP's for Parse classes programmatically. Classes need to be created first or else the server will throw errors. These errors can be ignored.
- [x] Add a read only key to the Parse server to enable read only access
- [x] Add new user, `parseRead` to dashboard who only has read only access
- [x] Move all binary environment variables to strings
- [x] Update README 