### PR TITLE
update to parse-server 5.0.0-alpha.29

### DIFF
--- a/docker-compose.mongo.yml
+++ b/docker-compose.mongo.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
     parse:
-        image: netreconlab/parse-hipaa:5.0.0-alpha.23
+        image: netreconlab/parse-hipaa:latest
         environment:
             PARSE_SERVER_APPLICATION_ID: E036A0C5-6829-4B40-9B3B-3E05F6DF32B2
             PARSE_SERVER_PRIMARY_KEY: E2466756-93CF-4C05-BA44-FF5D9C34E99F
@@ -34,7 +34,7 @@ services:
             - db
         command: ["node", "index.js"]
     dashboard:
-        image: parseplatform/parse-dashboard:4.0.0
+        image: parseplatform/parse-dashboard:latest
         environment:
             PARSE_DASHBOARD_TRUST_PROXY: 1
             PARSE_DASHBOARD_COOKIE_SESSION_SECRET: AB8849B6-D725-4A75-AA73-AB7103F0363F # This should be constant across all deployments on your system

--- a/docker-compose.no.hipaa.yml
+++ b/docker-compose.no.hipaa.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
     parse:
-        image: netreconlab/parse-hipaa:5.0.0-alpha.23
+        image: netreconlab/parse-hipaa:latest
         environment:
             PARSE_SERVER_APPLICATION_ID: E036A0C5-6829-4B40-9B3B-3E05F6DF32B2
             PARSE_SERVER_PRIMARY_KEY: E2466756-93CF-4C05-BA44-FF5D9C34E99F
@@ -37,7 +37,7 @@ services:
             - db
         command: ["./wait-for-postgres.sh", "db", "node", "index.js"]
     dashboard:
-        image: parseplatform/parse-dashboard:4.0.0
+        image: parseplatform/parse-dashboard:latest
         environment:
             PARSE_DASHBOARD_TRUST_PROXY: 1
             PARSE_DASHBOARD_COOKIE_SESSION_SECRET: AB8849B6-D725-4A75-AA73-AB7103F0363F # This should be constant across all deployments on your system

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
     parse:
-        image: netreconlab/parse-hipaa:5.0.0-alpha.23
+        image: netreconlab/parse-hipaa:latest
         environment:
             PARSE_SERVER_APPLICATION_ID: E036A0C5-6829-4B40-9B3B-3E05F6DF32B2
             PARSE_SERVER_PRIMARY_KEY: E2466756-93CF-4C05-BA44-FF5D9C34E99F
@@ -37,7 +37,7 @@ services:
         depends_on:
             - db
     dashboard:
-        image: parseplatform/parse-dashboard:4.0.0
+        image: parseplatform/parse-dashboard:latest
         environment:
             PARSE_DASHBOARD_TRUST_PROXY: 1
             PARSE_DASHBOARD_COOKIE_SESSION_SECRET: AB8849B6-D725-4A75-AA73-AB7103F0363F # This should be constant across all deployments on your system

--- a/parse/Dockerfile
+++ b/parse/Dockerfile
@@ -1,4 +1,4 @@
-FROM parseplatform/parse-server:5.0.0-alpha.28
+FROM parseplatform/parse-server:5.0.0-alpha.29
 
 USER root
 RUN apk add postgresql-client;

--- a/parse/Dockerfile
+++ b/parse/Dockerfile
@@ -1,4 +1,4 @@
-FROM parseplatform/parse-server:5.0.0-alpha.29
+FROM parseplatform/parse-server:5.0.0-alpha.28
 
 USER root
 RUN apk add postgresql-client;

--- a/parse/Dockerfile
+++ b/parse/Dockerfile
@@ -1,4 +1,4 @@
-FROM parseplatform/parse-server:5.0.0-alpha.26
+FROM parseplatform/parse-server:5.0.0-alpha.29
 
 USER root
 RUN apk add postgresql-client;


### PR DESCRIPTION
The following releases contain the security patch for parse-server security advisory [GHSA-p6h4-93qp-jhcm](https://github.com/parse-community/parse-server/security/advisories/GHSA-p6h4-93qp-jhcm):

- [x] 5.0.0-alpha.29
- [x] 5.0.0-alpha.28
- [x] 4.10.7