### PR TITLE
add redis back to heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -205,6 +205,10 @@
           "as": "db"
         },
         {
+          "plan": "heroku-redis",
+          "as": "redis"
+        },
+        {
           "plan": "scheduler"
         },
         {

--- a/app.json
+++ b/app.json
@@ -14,8 +14,8 @@
         "value": "4"
       },
       "NODE_TLS_REJECT_UNAUTHORIZED": {
-        "description": "Enable (or disable) rejecting unauthorized certificates, defaults to 1.",
-        "value": "1"
+        "description": "Enable (or disable) rejecting unauthorized certificates (needs to be 0 for redis), defaults to 0.",
+        "value": "0"
       },
       "PARSE_SERVER_APPLICATION_ID": {
         "description": "A unique identifier for your app.",


### PR DESCRIPTION
- [x] Adds redis back to heroku one button deployment
- [x] On heroku, sets `NODE_TLS_REJECT_UNAUTHORIZED = 0` since the redis connection uses a self signed cert given by heroku