### PR TITLE
update mongo image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 ![dashboard](https://user-images.githubusercontent.com/8621344/102236202-38f32080-3ec1-11eb-88d7-24e38e95f68d.png)
 
-Run your own HIPAA & GDPR compliant [parse-server](https://github.com/parse-community/parse-server) with [postgres](https://www.postgresql.org) or [mongo](https://github.com/netreconlab/parse-hipaa/blob/master/docker-compose.mongo.yml). parse-hipaa also includes [parse-dashboard](https://github.com/parse-community/parse-dashboard) for viewing/modifying your data in the Cloud. Since [parse-hipaa](https://github.com/netreconlab/parse-hipaa) is a pare-server, it can be used for [iOS](https://docs.parseplatform.org/ios/guide/), [Android](https://docs.parseplatform.org/android/guide/), [Flutter](https://github.com/parse-community/Parse-SDK-Flutter/tree/master/packages/flutter#getting-started), and web based apps ([JS, React Native, etc](https://docs.parseplatform.org/js/guide/)). API's such as [GraphQL](https://docs.parseplatform.org/graphql/guide/) and [REST](https://docs.parseplatform.org/rest/guide/) are enabled by default in parse-hipaa and can be tested directly or via the "API Console" in the Parse Dashboard. See the [Parse SDK documentation](https://parseplatform.org/#sdks) for details and examples of how to leverage parse-hipaa for your language(s) of interest. parse-hipaa includes the necessary database auditing and logging for HIPAA compliance. 
+Run your own HIPAA & GDPR compliant [parse-server](https://github.com/parse-community/parse-server) with [PostgreSQL](https://www.postgresql.org) or [MongoDB](https://github.com/netreconlab/parse-hipaa/blob/master/docker-compose.mongo.yml). parse-hipaa also includes [parse-dashboard](https://github.com/parse-community/parse-dashboard) for viewing/modifying your data in the Cloud. Since [parse-hipaa](https://github.com/netreconlab/parse-hipaa) is a pare-server, it can be used for [iOS](https://docs.parseplatform.org/ios/guide/), [Android](https://docs.parseplatform.org/android/guide/), [Flutter](https://github.com/parse-community/Parse-SDK-Flutter/tree/master/packages/flutter#getting-started), and web based apps ([JS, React Native, etc](https://docs.parseplatform.org/js/guide/)). API's such as [GraphQL](https://docs.parseplatform.org/graphql/guide/) and [REST](https://docs.parseplatform.org/rest/guide/) are enabled by default in parse-hipaa and can be tested directly or via the "API Console" in the Parse Dashboard. See the [Parse SDK documentation](https://parseplatform.org/#sdks) for details and examples of how to leverage parse-hipaa for your language(s) of interest. parse-hipaa includes the necessary database auditing and logging for HIPAA compliance. 
 
-The parse-hipaa repo provides the following:
+`parse-hipaa` provides the following:
 - [x] Auditing & logging at server-admin level (Parse) and at the database level (postgres or mongo)
 - [x] The User class (and the ParseCareKit classes if you are using them) are locked down and doesn't allow unauthenticated access (the standard parse-server allows unauthenticated read access by default)
 - [x] The creation of new Parse Classes and the addition of adding fields from the client-side are disabled. These can be created/added on the server-side using Parse Dashboard (the standard parse-server allows Class and field creation on the client-side by default)
@@ -77,7 +77,7 @@ You can use the one-button-click deployment to quickly deploy to Heroko. **Note 
 4. You can then follow the directions on heroku's site for [deployment](https://devcenter.heroku.com/articles/git) and [integration](https://devcenter.heroku.com/articles/github-integration)
 
 ### Local: Using Docker Image with Postgres or Mongo
-By default, the `docker-compose.yml` uses [postgres](https://www.postgresql.org). A [mongo](https://github.com/netreconlab/parse-hipaa/blob/master/docker-compose.mongo.yml) variant (uses [percona-server-mongodb](https://www.percona.com/software/mongodb/percona-server-for-mongodb) 4 is included in this repo). 
+By default, the `docker-compose.yml` uses [hipaa-postgres](https://github.com/netreconlab/hipaa-postgres/). The the `docker-compose.mongo.yml` uses [hipaa-mongo](https://github.com/netreconlab/hipaa-mongo/). 
 
 #### Postgres
 To use the Postgres HIPAA compliant variant of parse-hipaa, simply type:
@@ -95,7 +95,7 @@ If you would like to use a non-HIPAA compliant postgres version:
 ```docker-compose -f docker-compose.no.hipaa.yml up```
 
 #### Mongo (Non-HIPAA Compliant)
-A non-HIPAA compliant mongo version isn't provided as this is the default [parse-server](https://github.com/parse-community/parse-server#inside-a-docker-container) deployment and many examples of how to set this up are online already exist.
+A non-HIPAA compliant mongo version isn't provided as this is the default [parse-server](https://github.com/parse-community/parse-server#inside-a-docker-container) deployment and many examples of how to set this up already exist.
 
 #### Getting started
 parse-hipaa is made up of four (4) seperate docker images (you use 3 of them at a time) that work together as one system. It's important to set the environment variables for your parse-hipaa server. 
@@ -140,12 +140,9 @@ PG_PARSE_DB # Name of parse-hipaa database
 ###### netreconlab/hipaa-mongo
 ```bash
 # Warning, if you want to make changes to the vars below they need to be changed manually in /scripts/mongo-init.js as the env vars are not passed to the script
-MONGO_INITDB_ROOT_USERNAME # Username for mongo db. Should be MONGO_PARSE_USER
-MONGO_INITDB_ROOT_PASSWORD # Password for mongo db. Should be MONGO_PARSE_PASSWORD
-MONGO_INITDB_DATABASE # Name of mongo db. Should be MONGO_PARSE_DB
-MONGO_PARSE_USER # Username for logging into mongo db for parse-hipaa.
-MONGO_PARSE_PASSWORD # Password for logging into mongo db for parse-hipaa
-MONGO_PARSE_DB # Name of mongo db for parse-hipaa
+MONGO_INITDB_ROOT_USERNAME # Username for mongo db. Username for logging into mongo db for parse-hipaa.
+MONGO_INITDB_ROOT_PASSWORD # Password for mongo db. Password for logging into mongo db for parse-hipaa.
+MONGO_INITDB_DATABASE # Name of mongo db for parse-hipaa
 ```
 
 ###### netreconlab/parse-hipaa-dashboard

--- a/app.json
+++ b/app.json
@@ -170,8 +170,8 @@
         "value": "5000"
       },      
       "PARSE_SERVER_MOUNT_GRAPHQL": {
-        "description": "Enable graphql, default is 'true'.",
-        "value": "true"
+        "description": "Enable graphql, default is 'false'.",
+        "value": "false"
       },
       "PARSE_SERVER_GRAPH_QLSCHEMA": {
         "description": "Full path to your GraphQL custom schema.graphql file.",

--- a/docker-compose.mongo.yml
+++ b/docker-compose.mongo.yml
@@ -4,7 +4,7 @@ services:
     parse:
         image: netreconlab/parse-hipaa:latest
         environment:
-            CLUSTER_INSTANCES: 4
+            CLUSTER_INSTANCES: 1
             PARSE_SERVER_APPLICATION_ID: E036A0C5-6829-4B40-9B3B-3E05F6DF32B2
             PARSE_SERVER_PRIMARY_KEY: E2466756-93CF-4C05-BA44-FF5D9C34E99F
             PARSE_SERVER_READ_ONLY_PRIMARY_KEY: 367F7395-2E3A-46B1-ABA3-963A25D533C3
@@ -17,13 +17,22 @@ services:
             PARSE_SERVER_URL: http://parse:${PORT}${MOUNT_PATH}
             PARSE_PUBLIC_SERVER_URL: http://localhost:${PORT}${MOUNT_PATH}
             PARSE_SERVER_CLOUD: /parse-server/cloud/main.js
-            PARSE_SERVER_MOUNT_GRAPHQL: 'true'
+            PARSE_SERVER_MOUNT_GRAPHQL: 'false'
             PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' # Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
             PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' # Required to be true for ParseCareKit
             PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'
             PARSE_SERVER_DIRECT_ACCESS: 'false' # WARNING: Setting to 'true' is known to cause crashes on parse-hipaa running postgres
             PARSE_SERVER_ENABLE_PRIVATE_USERS: 'true'
             PARSE_SERVER_USING_PARSECAREKIT: 'true' # If you are not using ParseCareKit, set this to 'false'
+            PARSE_DASHBOARD_START: 'true'
+            PARSE_DASHBOARD_APP_NAME: Parse HIPAA
+            PARSE_DASHBOARD_SERVER_URL: http://localhost:${PORT}${MOUNT_PATH}
+            PARSE_DASHBOARD_USERNAMES: parse, parseRead
+            PARSE_DASHBOARD_USER_PASSWORDS: 1234, 1234
+            PARSE_DASHBOARD_USER_PASSWORD_ENCRYPTED: 'false'
+            PARSE_DASHBOARD_ALLOW_INSECURE_HTTP: 1
+            PARSE_DASHBOARD_COOKIE_SESSION_SECRET: AB8849B6-D725-4A75-AA73-AB7103F0363F # This should be constant across all deployments on your system
+            PARSE_DASHBOARD_MOUNT_PATH: /dashboard # This needs to be exactly what you plan it to be behind the proxy, i.e. If you want to access cs.uky.edu/dashboard it should be "/dashboard"
             PARSE_VERBOSE: 'false'
         ports:
             - 127.0.0.1:${PORT}:${PORT}
@@ -34,21 +43,8 @@ services:
         depends_on:
             - db
         command: ["node", "index.js"]
-    dashboard:
-        image: parseplatform/parse-dashboard:latest
-        environment:
-            PARSE_DASHBOARD_TRUST_PROXY: 1
-            PARSE_DASHBOARD_COOKIE_SESSION_SECRET: AB8849B6-D725-4A75-AA73-AB7103F0363F # This should be constant across all deployments on your system
-            MOUNT_PATH: /dashboard # This needs to be exactly what you plan it to be behind the proxy, i.e. If you want to access cs.uky.edu/dashboard it should be "/dashboard"
-        command: parse-dashboard --dev
-        volumes:
-            - ./dashboard/parse-dashboard-config.json:/src/Parse-Dashboard/parse-dashboard-config.json
-        ports:
-            - 127.0.0.1:${DASHBOARD_PORT}:${DASHBOARD_PORT}
-        depends_on:
-            - parse
     db:
-        image: netreconlab/hipaa-mongo:4.4
+        image: netreconlab/hipaa-mongo:latest
         environment:
             MONGO_INITDB_ROOT_USERNAME: ${MONGO_PARSE_USER}
             MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PARSE_PASSWORD}
@@ -59,7 +55,19 @@ services:
         # Uncomment volumes below to persist postgres data. Make sure to change directory to store data locally
         #volumes:
         #  - /My/Encrypted/Drive/db:/data/db
-        #  - /My/Encrypted/Drive/log/:/mongologs
-    scan:
-        image: netreconlab/clamscan:latest
-        restart: always
+        #  - /My/Encrypted/Drive/logs/:/logs
+    #scan:
+    #    image: netreconlab/clamscan:latest
+    #    restart: always
+    #dashboard:
+    #    image: netreconlab/parse-hipaa-dashboard:latest
+    #    environment:
+    #        PARSE_DASHBOARD_ALLOW_INSECURE_HTTP: 1
+    #        PARSE_DASHBOARD_COOKIE_SESSION_SECRET: AB8849B6-D725-4A75-AA73-AB7103F0363F # This should be constant across all deployments on your system
+    #        MOUNT_PATH: /dashboard # This needs to be exactly what you plan it to be behind the proxy, i.e. If you want to access cs.uky.edu/dashboard it should be "/dashboard"
+    #    volumes:
+    #        - ./dashboard/parse-dashboard-config.json:/parse-hipaa-dashboard/lib/parse-dashboard-config.json
+    #    ports:
+    #        - 127.0.0.1:${DASHBOARD_PORT}:${DASHBOARD_PORT}
+    #    depends_on:
+    #        - parse

--- a/docker-compose.no.hipaa.yml
+++ b/docker-compose.no.hipaa.yml
@@ -4,7 +4,7 @@ services:
     parse:
         image: netreconlab/parse-hipaa:latest
         environment:
-            CLUSTER_INSTANCES: 4
+            CLUSTER_INSTANCES: 1
             PARSE_SERVER_APPLICATION_ID: E036A0C5-6829-4B40-9B3B-3E05F6DF32B2
             PARSE_SERVER_PRIMARY_KEY: E2466756-93CF-4C05-BA44-FF5D9C34E99F
             PARSE_SERVER_READ_ONLY_PRIMARY_KEY: 367F7395-2E3A-46B1-ABA3-963A25D533C3
@@ -63,6 +63,3 @@ services:
     # Uncomment volumes below to persist postgres data. Make sure to change directory to store data locally
     #volumes:
     #    - ./data:/var/lib/postgresql/data
-    scan:
-        image: netreconlab/clamscan:latest
-        restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
             PARSE_SERVER_URL: http://parse:${PORT}${MOUNT_PATH}
             PARSE_SERVER_PUBLIC_URL: http://localhost:${PORT}${MOUNT_PATH}
             PARSE_SERVER_CLOUD: /parse-server/cloud/main.js
-            PARSE_SERVER_MOUNT_GRAPHQL: 'true'
+            PARSE_SERVER_MOUNT_GRAPHQL: 'false'
             PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' # Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
             PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' # Required to be true for ParseCareKit
             PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'

--- a/parse/index.js
+++ b/parse/index.js
@@ -1,13 +1,13 @@
 // Example express application adding the parse-server module to expose Parse
 // compatible API routes.
+
+const { default: ParseServer, ParseGraphQLServer, RedisCacheAdapter } = require('./lib');
+const { GridFSBucketAdapter } = require('./lib/Adapters/Files/GridFSBucketAdapter');
+const ParseAuditor = require('./node_modules/parse-auditor/src/index.js');
 const express = require('express');
-const { default: ParseServer, ParseGraphQLServer, RedisCacheAdapter } = require('./lib/index');
-const FSFilesAdapter = require('@parse/fs-files-adapter');
-const GridFSBucketAdapter = require('./lib/Adapters/Files/GridFSBucketAdapter')
-  .GridFSBucketAdapter;
 const path = require('path');
 const cors = require('cors');
-const ParseAuditor = require('./node_modules/parse-auditor/src/index.js');
+const FSFilesAdapter = require('@parse/fs-files-adapter');
 
 const mountPath = process.env.PARSE_SERVER_MOUNT_PATH || '/parse';
 const graphMountPath = process.env.PARSE_SERVER_GRAPHQL_PATH || '/graphql';


### PR DESCRIPTION
- [x] Don't mount GraphQL by default when running hipaa
- [x] small refactor of index.js 
- [x] point to db repos in README
- [x] All `docker-compose` files use native [parse-hipaa-dashboard](https://github.com/netreconlab/parse-hipaa-dashboard). The `docker-compose.mongo` file uses the `parse-dashboard` 