### PR TITLE
fix: Disable default password validator and rate limiter

### DIFF
--- a/app.json
+++ b/app.json
@@ -159,7 +159,7 @@
       },
       "PARSE_SERVER_RATE_LIMIT": {
         "description": "Options to limit repeated requests to Parse Server APIs. This can be used to protect sensitive endpoints such as `/requestPasswordReset` from brute-force attacks or Server as a whole from denial-of-service (DoS) attacks. Mind the following limitations: rate limits applied per IP address; this limits protection against distributed denial-of-service (DDoS) attacks where many requests are coming from various IP addresses; if multiple Parse Server instances are behind a load balancer or ran in a cluster, each instance will calculate it's own request rates, independent from other instances; this limits the applicability of this feature when using a load balancer and another rate limiting solution that takes requests across all instances into account may be more suitable; this feature provides basic protection against DoS attacks, but a more sophisticated solution works earlier in the request flow and prevents a malicious requests to even reach a server instance; it's therefore recommended to implement a solution according to architecture and user case.",
-        "value": "true"
+        "value": "false"
       },
       "PARSE_SERVER_RATE_LIMIT_ERROR_RESPONSE_MESSAGE": {
         "description": "The error message that should be returned in the body of the HTTP 429 response when the rate limit is hit. Default is `Too many requests.`",
@@ -355,7 +355,7 @@
       },
       "PARSE_SERVER_PASSWORD_POLICY_DO_NOT_ALLOW_USERNAME": {
         "description": "Set to true to disallow the username as part of the password.",
-        "value": "false"
+        "value": "true"
       },
       "PARSE_SERVER_PASSWORD_POLICY_MAX_PASSWORD_AGE": {
         "description": "Set the number of days after which a password expires. Login attempts fail if the user does not reset the password before expiration.",
@@ -379,7 +379,7 @@
       },
       "PARSE_SERVER_PASSWORD_POLICY_VALIDATOR_PATTERN": {
         "description": "Set the regular expression validation pattern a password must match to be accepted. Defaults to enforcing passwords to have atleast: 8 chars with at least 1 lower case, 1 upper case and 1 digit",
-        "value": "/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{8,})/"
+        "required": false
       },
       "PARSE_SERVER_LOG_LEVELS_TRIGGER_AFTER": {
         "description": "Log level used by the Cloud Code Triggers `afterSave`, `afterDelete`, `afterSaveFile`, `afterDeleteFile`, `afterFind`, `afterLogout`.",


### PR DESCRIPTION
Fixes some issues below with the Heroku deployment:

1. The password validator doesn't like the string format being passed from the Heroku environment. To enable this in the future, it needs to be converted to the proper type. The fix is to not specify a default value in Heroku and let `index.js` use its' default value for `PARSE_SERVER_PASSWORD_POLICY_VALIDATOR_PATTERN`
2. The default configuration for not allowing the username in the password has been switched from `false` to `true`
3. The rate limiter has been turned off by default. This can be enabled, but a proper value for `PARSE_SERVER_RATE_LIMIT_REQUEST_COUNT` should be set as `100` can be too low for using the ParseCareKit sample app