### PR TITLE
fix: Config S3 adapter with DB adapters

### DIFF
--- a/parse/index.js
+++ b/parse/index.js
@@ -219,6 +219,17 @@ if ("PARSE_SERVER_ENCRYPTION_KEY" in process.env) {
   filesFSAdapterOptions.encryptionKey = process.env.PARSE_SERVER_ENCRYPTION_KEY;
 }
 
+if ("PARSE_SERVER_DATABASE_URI" in process.env) {
+  if (process.env.PARSE_SERVER_DATABASE_URI.indexOf('postgres') !== -1) {
+    filesAdapter = new FSFilesAdapter(filesFSAdapterOptions);
+  }
+} else if ("DB_URL" in process.env) {
+  if (process.env.DB_URL.indexOf('postgres') !== -1) {
+    filesAdapter = new FSFilesAdapter(filesFSAdapterOptions);
+    databaseUri = `${databaseUri}?ssl=true&rejectUnauthorized=false`;
+  }  
+}
+
 if ("PARSE_SERVER_S3_BUCKET" in process.env) {
   filesAdapter = {
     "module": "@parse/s3-files-adapter",
@@ -228,15 +239,6 @@ if ("PARSE_SERVER_S3_BUCKET" in process.env) {
       "ServerSideEncryption": process.env.PARSE_SERVER_S3_BUCKET_ENCRYPTION || 'AES256', //AES256 or aws:kms, or if you do not pass this, encryption won't be done
     }
   }
-} else if ("PARSE_SERVER_DATABASE_URI" in process.env) {
-  if (process.env.PARSE_SERVER_DATABASE_URI.indexOf('postgres') !== -1) {
-    filesAdapter = new FSFilesAdapter(filesFSAdapterOptions);
-  }
-} else if ("DB_URL" in process.env) {
-  if (process.env.DB_URL.indexOf('postgres') !== -1) {
-    filesAdapter = new FSFilesAdapter(filesFSAdapterOptions);
-    databaseUri = `${databaseUri}?ssl=true&rejectUnauthorized=false`;
-  }  
 }
 
 if (Object.keys(filesAdapter).length === 0) {


### PR DESCRIPTION
The S3 adapter config should be setup after the database adapters since Postgres needs to be configured with a standard file adapter if S3 isn't present. If S3 is present, replace the standard file adapter.