### PR TITLE
fix: Set encodeParseObjectInCloudFunction to true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: [ '*.*.*', '*.*.*-*' ]
 
 env:
-  LATEST: '7.4.0'
+  LATEST: '7.4.1'
   REGISTRY: docker.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/app.json
+++ b/app.json
@@ -241,6 +241,10 @@
         "description": "Enables database real-time hooks to update single schema cache. Set to `true` if using multiple Parse Servers instances connected to the same database. Failing to do so will cause a schema change to not propagate to all instances and re-syncing will only happen when the instances restart.",
         "value": "true"
       },
+      "PARSE_SERVER_ENCODE_PARSE_OBJECT_IN_CLOUD_FUNCTION": {
+        "description": "If set to `true`, a `Parse.Object` that is in the payload when calling a Cloud Function will be converted to an instance of `Parse.Object`. If `false`, the object will not be converted and instead be a plain JavaScript object, which contains the raw data of a `Parse.Object` but is not an actual instance of `Parse.Object`. Default is `false`. The expected behavior would be that the object is converted to an instance of `Parse.Object`, so you would normally set this option to `true`. The default is `false` because this is a temporary option that has been introduced to avoid a breaking change when fixing a bug where JavaScript objects are not converted to actual instances of `Parse.Object`.",
+        "value": "true"
+      },
       "PARSE_SERVER_DIRECT_ACCESS": {
         "description": "WARNING: Setting to 'true' is known to cause crashes on parse-hipaa running postgres.",
         "value": "false"

--- a/docker-compose.dashboard.yml
+++ b/docker-compose.dashboard.yml
@@ -22,6 +22,7 @@ services:
             PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' # Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
             PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' # Required to be true for ParseCareKit
             PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'
+            PARSE_SERVER_ENCODE_PARSE_OBJECT_IN_CLOUD_FUNCTION: 'true'
             PARSE_SERVER_DIRECT_ACCESS: 'false' # WARNING: Setting to 'true' is known to cause crashes on parse-hipaa running postgres
             PARSE_SERVER_ENABLE_PRIVATE_USERS: 'true'
             PARSE_SERVER_USING_PARSECAREKIT: 'true' # If you are not using ParseCareKit, set this to 'false'

--- a/docker-compose.mongo.dashboard.yml
+++ b/docker-compose.mongo.dashboard.yml
@@ -22,6 +22,7 @@ services:
             PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' # Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
             PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' # Required to be true for ParseCareKit
             PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'
+            PARSE_SERVER_ENCODE_PARSE_OBJECT_IN_CLOUD_FUNCTION: 'true'
             PARSE_SERVER_DIRECT_ACCESS: 'false' # WARNING: Setting to 'true' is known to cause crashes on parse-hipaa running postgres
             PARSE_SERVER_ENABLE_PRIVATE_USERS: 'true'
             PARSE_SERVER_USING_PARSECAREKIT: 'true' # If you are not using ParseCareKit, set this to 'false'

--- a/docker-compose.mongo.yml
+++ b/docker-compose.mongo.yml
@@ -22,6 +22,7 @@ services:
             PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' # Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
             PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' # Required to be true for ParseCareKit
             PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'
+            PARSE_SERVER_ENCODE_PARSE_OBJECT_IN_CLOUD_FUNCTION: 'true'
             PARSE_SERVER_DIRECT_ACCESS: 'false' # WARNING: Setting to 'true' is known to cause crashes on parse-hipaa running postgres
             PARSE_SERVER_ENABLE_PRIVATE_USERS: 'true'
             PARSE_SERVER_USING_PARSECAREKIT: 'true' # If you are not using ParseCareKit, set this to 'false'

--- a/docker-compose.no.hipaa.yml
+++ b/docker-compose.no.hipaa.yml
@@ -22,6 +22,7 @@ services:
             PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' # Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
             PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' # Required to be true for ParseCareKit
             PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'
+            PARSE_SERVER_ENCODE_PARSE_OBJECT_IN_CLOUD_FUNCTION: 'true'
             PARSE_SERVER_DIRECT_ACCESS: 'false' # WARNING: Setting to 'true' is known to cause crashes on parse-hipaa running postgres
             PARSE_SERVER_ENABLE_PRIVATE_USERS: 'true'
             PARSE_SERVER_USING_PARSECAREKIT: 'false' # If you are not using ParseCareKit, set this to 'false'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
             PARSE_SERVER_ALLOW_CLIENT_CLASS_CREATION: 'false' # Don't allow classes to be created on the client side. You can create classes by using ParseDashboard instead
             PARSE_SERVER_ALLOW_CUSTOM_OBJECTID: 'true' # Required to be true for ParseCareKit
             PARSE_SERVER_ENABLE_SCHEMA_HOOKS: 'true'
+            PARSE_SERVER_ENCODE_PARSE_OBJECT_IN_CLOUD_FUNCTION: 'true'
             PARSE_SERVER_DIRECT_ACCESS: 'false' # WARNING: Setting to 'true' is known to cause crashes on parse-hipaa running postgres
             PARSE_SERVER_ENABLE_PRIVATE_USERS: 'true'
             PARSE_SERVER_USING_PARSECAREKIT: 'true' # If you are not using ParseCareKit, set this to 'false' 

--- a/parse/index.js
+++ b/parse/index.js
@@ -10,7 +10,7 @@ const cors = require('cors');
 const FSFilesAdapter = require('@parse/fs-files-adapter');
 
 const mountPath = process.env.PARSE_SERVER_MOUNT_PATH || '/parse';
-const graphMountPath = process.env.PARSE_SERVER_GRAPHQL_PATH || '/graphql';
+const graphQLPath = process.env.PARSE_SERVER_GRAPHQL_PATH || '/graphql';
 const dashboardMountPath = process.env.PARSE_DASHBOARD_MOUNT_PATH || '/dashboard';
 const applicationId = process.env.PARSE_SERVER_APPLICATION_ID || 'myAppId';
 const primaryKey = process.env.PARSE_SERVER_PRIMARY_KEY || 'myKey';
@@ -30,7 +30,7 @@ if ("NEW_RELIC_APP_NAME" in process.env) {
 const publicServerURL = process.env.PARSE_SERVER_PUBLIC_URL || serverURL;
 const url = new URL(publicServerURL);
 const graphURL = new URL(publicServerURL);
-graphURL.pathname = graphMountPath;
+graphURL.pathname = graphQLPath;
 const dashboardURL = new URL(publicServerURL);
 dashboardURL.pathname = dashboardMountPath;
 
@@ -107,6 +107,11 @@ if (process.env.PARSE_SERVER_ALLOW_CUSTOM_OBJECTID == 'true') {
 let enableSchemaHooks = false;
 if (process.env.PARSE_SERVER_DATABASE_ENABLE_SCHEMA_HOOKS == 'true') {
   enableSchemaHooks = true
+}
+
+let encodeParseObjectInCloudFunction = false;
+if (process.env.PARSE_SERVER_ENCODE_PARSE_OBJECT_IN_CLOUD_FUNCTION == 'true') {
+  encodeParseObjectInCloudFunction = true
 }
 
 let useDirectAccess = false;
@@ -257,6 +262,9 @@ if (Object.keys(filesAdapter).length === 0) {
 
 configuration = {
   databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
+  databaseOptions: {
+    enableSchemaHooks: enableSchemaHooks,
+  },
   cloud: process.env.PARSE_SERVER_CLOUD || __dirname + '/cloud/main.js',
   appId: applicationId,
   masterKey: primaryKey,
@@ -285,7 +293,7 @@ configuration = {
     fileExtensions: fileExtensions,
   },
   maxUploadSize: fileMaxUploadSize,
-  enableSchemaHooks: enableSchemaHooks,
+  encodeParseObjectInCloudFunction: encodeParseObjectInCloudFunction,
   directAccess: useDirectAccess,
   allowExpiredAuthDataToken: allowExpiredAuthDataToken,
   enforcePrivateUsers: enforcePrivateUsers,
@@ -300,11 +308,9 @@ configuration = {
   startLiveQueryServer: startLiveQueryServer,
   liveQuery: {
     classNames: classNames, // List of classes to support for query subscriptions
-    websocketTimeout: websocketTimeout,
-    cacheTimeout: cacheTimeout
   },
   mountGraphQL: enableGraphQL, 
-  graphMountPath: graphMountPath,
+  graphQLPath: graphQLPath,
   mountPlayground: mountPlayground,
   playgroundPath: playgroundPath,
   verifyUserEmails: verifyUserEmails,


### PR DESCRIPTION
- [x] Set `encodeParseObjectInCloudFunction` to true by default. This helps with dealing with `Parse.Objects` in cloud code
- [x] Fixes issues with properly setting/enabling `enableSchemaHooks` and `graphQLPath` 